### PR TITLE
[TASK] Allowed TYPO3 v.7.x.y

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "sjbr/static_info_tables_de": "*"
   },
   "require": {
-    "typo3/cms-core": ">=6.2,8.*",
+    "typo3/cms-core": ">=6.2",
     "sjbr/static_info_tables": "^6.3.1"
   }
 }


### PR DESCRIPTION
With the current setup, it was not possible to install on TYPO3 7.x.y, so I removed the 8.0 constrain so it just have to be above Version 6.2.

PS: I don't know where the origin lives anymore. So making my pull request here.